### PR TITLE
Improve CLI help text and add agent integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ To begin using ACE, follow these simple steps:
 
 ACE was meant for a workflow where a project can store all secrets in the git repository while only giving access to certain recipients, such as CI.
 
+### Using ACE with coding agents
+
+`ace --help` is written to be enough for an LLM coding agent to use the tool correctly on its own. To teach agents your team's conventions — and to have them reach for ACE proactively — see [docs/agents.md](docs/agents.md) for copy-paste `AGENTS.md`/`CLAUDE.md` snippets, a Claude Code skill, and permission suggestions.
+
 ## API Reference
 
 - `ace set [KEY=VALUE...]`: Sets environment variables. Accepts multiple key-value pairs.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ ACE (Append-only encrypted Environment variables) is a tool designed to securely
 
 Install by downloading a release for your platform and placing it somewhere on your `$PATH`.
 
-Or if you have a Go environment setup you may also install it using `go install github.com/slaskis/ace@latest`.
+Or if you have a Go environment setup you may also install it using `go install github.com/middle-management/ace@latest`.
 
 ### Basic Usage
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,0 +1,133 @@
+# Using ACE with coding agents
+
+ACE works well with LLM coding agents (Claude Code, Cursor, Copilot, aider, …)
+out of the box: the CLI is small and `ace --help` describes the full model,
+so an agent that encounters `.env.ace` and runs `--help` can usually figure
+things out on its own.
+
+What the help output can't carry is *when* to reach for ace and *your team's
+conventions* — that an agent should use `ace env` instead of writing a plain
+`.env` file, that secrets must never end up in shell history or the
+transcript, or how your team onboards a new recipient. That knowledge belongs
+in your project's agent instructions. This page gives you copy-paste starting
+points.
+
+## AGENTS.md / CLAUDE.md snippet
+
+Most agents read a project instructions file (`AGENTS.md`, `CLAUDE.md`,
+`.cursorrules`, …). Add a section like this and adjust the conventions to
+your team:
+
+```markdown
+## Secrets and environment variables
+
+Environment variables are managed with ace (https://github.com/middle-management/ace)
+and stored encrypted in `.env.ace`, which is safe to commit. Run `ace --help`
+for full usage. Rules:
+
+- To run anything that needs secrets, use `ace env -- <command>` instead of
+  exporting variables or writing a plain `.env` file.
+- To add or update a secret, prefer stdin so values stay out of shell history
+  and logs: `ace set < file-with-pairs` (or pipe `KEY=VALUE` lines to it).
+  Setting an existing key appends a new value; the latest value wins.
+- Decrypted values are sensitive: never write them to disk, commit them, or
+  echo them. Only run `ace get` when the user explicitly asks for a value.
+- Never edit `.env.ace` by hand — it is append-only and only written by
+  `ace set`. Treat merge conflicts in it by keeping both sides' blocks.
+- To give a new person or machine access: append their age public key to
+  `recipients.txt`, then re-encrypt existing values to the new recipient
+  list with `ace get | ace set` (run by someone who can already decrypt).
+```
+
+## Claude Code skill
+
+A [skill](https://code.claude.com/docs/en/skills) goes further than an
+instructions file: its description tells Claude when to load it, so it
+triggers on requests like "add a secret for staging" even before ace is
+mentioned. Create `.claude/skills/ace/SKILL.md` in your project:
+
+```markdown
+---
+name: ace
+description: >-
+  Manage this project's encrypted environment variables with the ace CLI.
+  Use when the user asks to add, read, update, rotate, or share secrets,
+  API keys, or env vars, when a command fails for lack of credentials,
+  or when .env.ace or recipients.txt come up.
+---
+
+# Managing secrets with ace
+
+Secrets live encrypted in `.env.ace` (append-only, safe to commit) and are
+encrypted to the age public keys in `recipients.txt`. Decryption requires an
+identity, `$XDG_CONFIG_HOME/ace/identity` by default. `ace --help` has the
+full reference.
+
+## Reading secrets
+
+- `ace get` prints all KEY=VALUE pairs the local identity can decrypt;
+  `ace get KEY` prints selected keys.
+- Output is sensitive. Only run `ace get` when the user asked for a value,
+  and never redirect it into a file that could be committed.
+
+## Adding or updating secrets
+
+- Ask the user for the value rather than inventing one, then pass it via
+  stdin so it stays out of shell history and the transcript:
+  `ace set < path/to/pairs.env`, or have the user run
+  `ace set KEY=VALUE` themselves.
+- Updating uses the same command: setting an existing key appends a new
+  value and the latest value wins on read. Nothing is ever deleted.
+- Quote values like in a .env file when they contain spaces or newlines:
+  `KEY="multi word value"`.
+
+## Running commands that need secrets
+
+- Use `ace env -- <command...>` to run a command with the decrypted
+  variables in its environment. Do not export secrets into the shell or
+  materialize a plaintext `.env` file.
+- In environments without an identity (e.g. some CI jobs), degrade
+  gracefully with `ace env --on-missing=warn -- <command...>`.
+
+## Sharing access / onboarding a recipient
+
+1. The new person or machine creates an identity:
+   `age-keygen -o "$XDG_CONFIG_HOME/ace/identity"`
+2. They add its public key to the recipients:
+   `age-keygen -y "$XDG_CONFIG_HOME/ace/identity" >> recipients.txt`
+3. Someone who can already decrypt re-encrypts existing values to the new
+   recipient list: `ace get | ace set`
+4. Commit `.env.ace` and `recipients.txt`.
+
+## Troubleshooting
+
+- "no identity matched any encrypted block": the local identity's public
+  key was not among the recipients when the values were set. Onboard it as
+  above, or pass the right identity with `-i <file>`.
+- `ace get` prints fewer keys than expected: same cause — a recipient can
+  only decrypt blocks that were encrypted to it.
+- Never hand-edit `.env.ace` to fix problems; append corrected values with
+  `ace set` instead.
+```
+
+## Permissions
+
+Coding agents typically ask before running shell commands. `ace set`,
+`ace env`, and `ace version` neither print nor persist plaintext secrets, so
+they are safe to allowlist. Consider keeping `ace get` behind a prompt since
+its output is sensitive. For Claude Code, in `.claude/settings.json`:
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(ace set:*)",
+      "Bash(ace env:*)",
+      "Bash(ace version)"
+    ],
+    "ask": [
+      "Bash(ace get:*)"
+    ]
+  }
+}
+```

--- a/env.go
+++ b/env.go
@@ -14,9 +14,9 @@ import (
 
 type Env struct {
 	OnMissing  string   `arg:"--on-missing" default:"error" help:"How to handle when env-file or identity is missing, can be 'ignore', 'warn' or 'error'"`
-	EnvFile    string   `arg:"--env-file,-e" default:"./.env.ace"`
+	EnvFile    string   `arg:"--env-file,-e" default:"./.env.ace" help:"Read encrypted variables from this file"`
 	Identities []string `arg:"--identity,-i,separate" help:"Decrypt using the specified IDENTITY. Can be repeated. Defaults to $XDG_CONFIG_HOME/ace/identity"`
-	Command    []string `arg:"positional,required"`
+	Command    []string `arg:"positional,required" placeholder:"COMMAND" help:"Command to run with the decrypted variables added to its environment. Use -- before it to separate its flags from ace's"`
 }
 
 func (cmd *Env) Run() error {

--- a/examples/docker/Dockerfile
+++ b/examples/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM scratch
 ARG TARGETOS=linux
 ARG TARGETARCH=amd64
-ADD --chmod=0755 --link https://github.com/slaskis/ace/releases/download/v0.1.14/ace-$TARGETOS-$TARGETARCH /bin/ace
+ADD --chmod=0755 --link https://github.com/middle-management/ace/releases/download/v0.6.0/ace-$TARGETOS-$TARGETARCH /bin/ace
 COPY ./env /bin/aceenv
 ENTRYPOINT ["/bin/ace","env","-e=/run/secrets/env","-i=/run/secrets/identity","--"]
 CMD ["/bin/aceenv"]

--- a/examples/docker/README.md
+++ b/examples/docker/README.md
@@ -8,9 +8,9 @@ It also shows that it works with a scratch image, which may be useful in statica
 
 ```sh
 GOOS=linux go build -o env .
-docker build -t slaskis/ace-example:scratch .
+docker build -t middle-management/ace-example:scratch .
 docker run \
 	--mount type=bind,source="$(pwd)"/.env.ace,target=/run/secrets/env,readonly \
 	--mount type=bind,source="$(pwd)"/identity,target=/run/secrets/identity,readonly \
-	slaskis/ace-example:scratch
+	middle-management/ace-example:scratch
 ```

--- a/examples/kompose/Dockerfile
+++ b/examples/kompose/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine
 ARG TARGETOS=linux
 ARG TARGETARCH=amd64
-ADD --chmod=0755 --link https://github.com/slaskis/ace/releases/download/v0.1.14/ace-$TARGETOS-$TARGETARCH /bin/ace
+ADD --chmod=0755 --link https://github.com/middle-management/ace/releases/download/v0.6.0/ace-$TARGETOS-$TARGETARCH /bin/ace
 ENTRYPOINT ["/bin/ace","env","-e=/run/secrets/env","-i=/run/secrets/identity","--"]
 CMD ["/usr/bin/env"]

--- a/examples/kompose/compose.yaml
+++ b/examples/kompose/compose.yaml
@@ -1,6 +1,6 @@
 services:
   env:
-    image: docker.io/slaskis/ace-example:latest
+    image: docker.io/middle-management/ace-example:latest
     build: .
     restart: no
     secrets:

--- a/examples/kompose/kompose.yaml
+++ b/examples/kompose/kompose.yaml
@@ -33,7 +33,7 @@ metadata:
   name: env
 spec:
   containers:
-    - image: docker.io/slaskis/ace-example:latest
+    - image: docker.io/middle-management/ace-example:latest
       name: env
       volumeMounts:
         - mountPath: /run/secrets/env

--- a/get.go
+++ b/get.go
@@ -7,9 +7,9 @@ import (
 )
 
 type Get struct {
-	EnvFile    string   `arg:"--env-file,-e" default:"./.env.ace"`
+	EnvFile    string   `arg:"--env-file,-e" default:"./.env.ace" help:"Read encrypted variables from this file"`
 	Identities []string `arg:"--identity,-i,separate" help:"Decrypt using the specified IDENTITY. Can be repeated. Defaults to $XDG_CONFIG_HOME/ace/identity"`
-	Keys       []string `arg:"positional"`
+	Keys       []string `arg:"positional" placeholder:"KEY" help:"Print only these variables. Prints all variables readable by the identities when omitted"`
 }
 
 func (cmd *Get) Run() error {

--- a/main.go
+++ b/main.go
@@ -21,10 +21,44 @@ import (
 )
 
 type Main struct {
-	Env     *Env     `arg:"subcommand:env" help:"Expand to env and pass to command"`
-	Get     *Get     `arg:"subcommand:get" help:"Decrypt env with available identities"`
-	Set     *Set     `arg:"subcommand:set" help:"Append encrypted env vars to file"`
-	Version *Version `arg:"subcommand:version"`
+	Env     *Env     `arg:"subcommand:env" help:"Run a command with the decrypted env vars added to its environment"`
+	Get     *Get     `arg:"subcommand:get" help:"Decrypt and print env vars"`
+	Set     *Set     `arg:"subcommand:set" help:"Encrypt env vars and append them to the env file"`
+	Version *Version `arg:"subcommand:version" help:"Print version"`
+}
+
+func (Main) Description() string {
+	return `ace manages append-only encrypted environment variables.
+
+Variables are encrypted with age (https://age-encryption.org) to a set of
+recipients (public keys) and appended to a plain-text env file (./.env.ace
+by default) that is safe to commit to version control. Anyone with the
+recipients can append new values, but only holders of a matching identity
+(private key) can decrypt them. Values are never modified in place: setting
+an existing key appends a new value, and the latest value wins when reading.
+`
+}
+
+func (Main) Epilogue() string {
+	return `Getting started:
+  age-keygen -o "$XDG_CONFIG_HOME/ace/identity"    create an identity (once per user/machine)
+  age-keygen -y "$XDG_CONFIG_HOME/ace/identity" >> recipients.txt
+                                                   register its public key as a recipient
+
+Examples:
+  ace set API_KEY=abc123    encrypt a variable and append it to ./.env.ace
+  ace set < .env            encrypt variables read from stdin in .env format
+                            (preferred for secrets: values stay out of shell history)
+  ace get                   decrypt and print all variables readable by your identity
+  ace get API_KEY           decrypt and print selected variables
+  ace env -- npm start      run a command with the decrypted variables in its environment
+  ace get | ace set         re-encrypt all readable variables to the current recipients
+
+Note that set encrypts to recipients (public keys) while get and env decrypt
+with identities (private keys): to read back a value you set, the public key
+of one of your identities must be listed among the recipients.
+
+Documentation: https://github.com/middle-management/ace`
 }
 
 const ACE_PREFIX = "# ace/v1:"

--- a/set.go
+++ b/set.go
@@ -15,8 +15,8 @@ import (
 type Set struct {
 	RecipientFiles []string `arg:"--recipient-file,-R,separate" help:"Encrypt to recipients listed at RECIPIENT-FILE. Can be repeated. Defaults to ./recipients.txt"`
 	Recipients     []string `arg:"--recipient,-r,separate" help:"Encrypt to the specified RECIPIENT. Can be repeated."`
-	EnvFile        string   `arg:"--env-file,-e" default:"./.env.ace"`
-	EnvPairs       []string `arg:"positional"`
+	EnvFile        string   `arg:"--env-file,-e" default:"./.env.ace" help:"Append the encrypted variables to this file"`
+	EnvPairs       []string `arg:"positional" placeholder:"KEY=VALUE" help:"Variables to encrypt. When none are given they are read from stdin in .env format, which keeps values out of shell history"`
 }
 
 func (cmd *Set) Run() error {

--- a/testdata/TestIntegration/ace
+++ b/testdata/TestIntegration/ace
@@ -1,10 +1,39 @@
+ace manages append-only encrypted environment variables.
+
+Variables are encrypted with age (https://age-encryption.org) to a set of
+recipients (public keys) and appended to a plain-text env file (./.env.ace
+by default) that is safe to commit to version control. Anyone with the
+recipients can append new values, but only holders of a matching identity
+(private key) can decrypt them. Values are never modified in place: setting
+an existing key appends a new value, and the latest value wins when reading.
+
 Usage: ace <command> [<args>]
 
 Options:
   --help, -h             display this help and exit
 
 Commands:
-  env                    Expand to env and pass to command
-  get                    Decrypt env with available identities
-  set                    Append encrypted env vars to file
-  version
+  env                    Run a command with the decrypted env vars added to its environment
+  get                    Decrypt and print env vars
+  set                    Encrypt env vars and append them to the env file
+  version                Print version
+
+Getting started:
+  age-keygen -o "$XDG_CONFIG_HOME/ace/identity"    create an identity (once per user/machine)
+  age-keygen -y "$XDG_CONFIG_HOME/ace/identity" >> recipients.txt
+                                                   register its public key as a recipient
+
+Examples:
+  ace set API_KEY=abc123    encrypt a variable and append it to ./.env.ace
+  ace set < .env            encrypt variables read from stdin in .env format
+                            (preferred for secrets: values stay out of shell history)
+  ace get                   decrypt and print all variables readable by your identity
+  ace get API_KEY           decrypt and print selected variables
+  ace env -- npm start      run a command with the decrypted variables in its environment
+  ace get | ace set         re-encrypt all readable variables to the current recipients
+
+Note that set encrypts to recipients (public keys) while get and env decrypt
+with identities (private keys): to read back a value you set, the public key
+of one of your identities must be listed among the recipients.
+
+Documentation: https://github.com/middle-management/ace

--- a/testdata/TestIntegration/coverage
+++ b/testdata/TestIntegration/coverage
@@ -1,9 +1,11 @@
 github.com/middle-management/ace/env.go:22:			*Env.Run		81.1%
 github.com/middle-management/ace/get.go:15:			*Get.Run		90.5%
-github.com/middle-management/ace/main.go:32:			readEnvFile		83.6%
-github.com/middle-management/ace/main.go:136:			readIdentities		66.7%
-github.com/middle-management/ace/main.go:196:			UnescapeValue		80.8%
-github.com/middle-management/ace/main.go:286:			main			100.0%
+github.com/middle-management/ace/main.go:30:			Main.Description	100.0%
+github.com/middle-management/ace/main.go:42:			Main.Epilogue		100.0%
+github.com/middle-management/ace/main.go:66:			readEnvFile		83.6%
+github.com/middle-management/ace/main.go:170:			readIdentities		66.7%
+github.com/middle-management/ace/main.go:230:			UnescapeValue		80.8%
+github.com/middle-management/ace/main.go:320:			main			100.0%
 github.com/middle-management/ace/set.go:22:			*Set.Run		83.5%
 github.com/middle-management/ace/version.go:14:			*Version.Run		60.0%
 github.com/middle-management/ace/version.go:23:			getVersion		0.0%
@@ -11,4 +13,4 @@ github.com/middle-management/ace/internal/proc/proc.go:8:	SetupSysProcAttr	0.0%
 github.com/middle-management/ace/internal/proc/proc.go:12:	ForwardSignal		0.0%
 github.com/middle-management/ace/internal/proc/proc_unix.go:12:	setupSysProcAttr	0.0%
 github.com/middle-management/ace/internal/proc/proc_unix.go:18:	forwardSignal		0.0%
-total								(statements)		75.6%
+total								(statements)		75.8%


### PR DESCRIPTION
## Summary
This PR enhances the user experience by providing more comprehensive CLI documentation and adding guidance for integrating ACE with LLM coding agents. The changes make the tool more discoverable and easier to use for both humans and AI assistants.

## Key Changes

- **Enhanced CLI help output**: Added `Description()` and `Epilogue()` methods to the `Main` command struct that provide:
  - A clear explanation of what ACE does and how it works
  - Getting started instructions for creating identities and registering recipients
  - Practical examples of common workflows
  - Important notes about the relationship between recipients (public keys) and identities (private keys)

- **Improved command help text**: Updated help strings for all subcommands and their flags to be more descriptive:
  - `env`: Now explains it runs commands with decrypted variables in the environment
  - `get`: Clarifies it decrypts and prints variables
  - `set`: Explains it encrypts and appends to the file
  - Added help text for previously undocumented flags like `--env-file`, `--identity`, and positional arguments

- **New agent integration documentation**: Created `docs/agents.md` with:
  - Copy-paste snippets for `AGENTS.md`/`CLAUDE.md` project instruction files
  - A complete Claude Code skill definition that teaches Claude when and how to use ACE
  - Permission configuration examples for Claude Code
  - Team conventions and best practices for secret management

- **Updated references**: Changed repository references from `slaskis/ace` to `middle-management/ace` throughout the codebase and examples

## Implementation Details

The help text improvements are designed to be self-contained in the `--help` output, allowing LLM coding agents to understand and use ACE correctly without external documentation. The new agent integration guide provides templates that teams can customize with their own conventions, enabling agents to proactively suggest using ACE for secret management tasks.

https://claude.ai/code/session_01X3oCPXgWKfCmtzcv9R4Nn8