### PR TITLE
Fix release workflow for immutable releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,14 +1,17 @@
-name: Go
+name: Release
 
+# Immutable releases cannot receive assets after publishing, so instead of
+# reacting to a published release this builds on tag push, attaches the
+# assets to a draft release (drafts stay mutable) and then publishes it.
 on:
-  release:
-    types: [published]
+  push:
+    tags: ["v*"]
 
 jobs:
-  release:
+  build:
     runs-on: ubuntu-latest
     permissions:
-      contents: write # needed for uploading release assets
+      contents: read
       id-token: write # needed for keyless signing with cosign
     strategy:
       matrix:
@@ -28,7 +31,7 @@ jobs:
         run: go test -v ./...
 
       - name: Build
-        run: go build -ldflags '-s -w -X main.version=${{ github.event.release.tag_name }}' -o ace-${{ matrix.goos }}-${{ matrix.arch }} -v .
+        run: go build -ldflags '-s -w -X main.version=${{ github.ref_name }}' -o ace-${{ matrix.goos }}-${{ matrix.arch }} -v .
         env:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.arch }}
@@ -40,41 +43,37 @@ jobs:
             --output-signature ace-${{ matrix.goos }}-${{ matrix.arch }}.sig \
             --output-certificate ace-${{ matrix.goos }}-${{ matrix.arch }}.pem
 
-      - name: Upload Binary
-        uses: actions/github-script@v7
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v4
         with:
-          script: |
-            const fs = require('fs');
-            github.rest.repos.uploadReleaseAsset({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              release_id: context.payload.release.id,
-              name: "ace-${{ matrix.goos }}-${{ matrix.arch }}",
-              data: fs.readFileSync("ace-${{ matrix.goos }}-${{ matrix.arch }}")
-            })
+          name: ace-${{ matrix.goos }}-${{ matrix.arch }}
+          path: |
+            ace-${{ matrix.goos }}-${{ matrix.arch }}
+            ace-${{ matrix.goos }}-${{ matrix.arch }}.sig
+            ace-${{ matrix.goos }}-${{ matrix.arch }}.pem
+          if-no-files-found: error
 
-      - name: Upload Signature
-        uses: actions/github-script@v7
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # needed for creating the release
+    steps:
+      - name: Download Artifacts
+        uses: actions/download-artifact@v4
         with:
-          script: |
-            const fs = require('fs');
-            github.rest.repos.uploadReleaseAsset({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              release_id: context.payload.release.id,
-              name: "ace-${{ matrix.goos }}-${{ matrix.arch }}.sig",
-              data: fs.readFileSync("ace-${{ matrix.goos }}-${{ matrix.arch }}.sig")
-            })
+          path: dist
+          merge-multiple: true
 
-      - name: Upload Certificate
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            github.rest.repos.uploadReleaseAsset({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              release_id: context.payload.release.id,
-              name: "ace-${{ matrix.goos }}-${{ matrix.arch }}.pem",
-              data: fs.readFileSync("ace-${{ matrix.goos }}-${{ matrix.arch }}.pem")
-            })
+      - name: Create Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            --repo "$GITHUB_REPOSITORY" \
+            --draft \
+            --generate-notes \
+            dist/*
+          gh release edit "$GITHUB_REF_NAME" \
+            --repo "$GITHUB_REPOSITORY" \
+            --draft=false


### PR DESCRIPTION
## Why

The v0.7.0 release job failed with `Cannot upload assets to an immutable release` (HTTP 422), leaving the release without binaries. The workflow triggered on `release: published` and only then built and uploaded assets — but with immutable releases enabled, a release stops accepting assets the moment it is published, so that ordering can never work.

## What

Restructured `release.yaml` to do everything before publishing:

- Trigger on tag push (`v*`) instead of `release: published`.
- The existing build matrix is unchanged in substance (test, build with `-X main.version`, cosign keyless signing) — the version now comes from `github.ref_name` instead of the release event, and each platform uploads its binary/`.sig`/`.pem` as workflow artifacts.
- A final `release` job downloads all artifacts and runs `gh release create --draft --generate-notes` with every asset attached, then flips the draft to published with `gh release edit --draft=false`. Drafts stay mutable, so assets attach fine; the release becomes immutable only at publish, with all assets already in place.

Release notes are auto-generated from PRs, same as the "Generate release notes" button in the UI.

## Note on v0.7.0

The published v0.7.0 release is immutable and permanently has no binaries. After this merges, cutting `v0.7.1` (just pushing the tag — no UI steps needed anymore) will produce a complete release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W6XiCMKgVz5khscQFxPFaC

---
_Generated by [Claude Code](https://claude.ai/code/session_01W6XiCMKgVz5khscQFxPFaC)_