### PR TITLE
Allow cutting releases from the Actions tab, bump Node 24 actions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,9 +3,18 @@ name: Release
 # Immutable releases cannot receive assets after publishing, so instead of
 # reacting to a published release this builds on tag push, attaches the
 # assets to a draft release (drafts stay mutable) and then publishes it.
+#
+# A release can also be cut from the Actions tab with "Run workflow" by
+# entering a new tag name: the tag is then created by publishing the release.
 on:
   push:
     tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to create and release, e.g. v0.7.2"
+        required: true
+        type: string
 
 jobs:
   build:
@@ -13,14 +22,16 @@ jobs:
     permissions:
       contents: read
       id-token: write # needed for keyless signing with cosign
+    env:
+      TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
     strategy:
       matrix:
         goos: [linux, windows, darwin]
         arch: [amd64, arm64]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
@@ -31,7 +42,7 @@ jobs:
         run: go test -v ./...
 
       - name: Build
-        run: go build -ldflags '-s -w -X main.version=${{ github.ref_name }}' -o ace-${{ matrix.goos }}-${{ matrix.arch }} -v .
+        run: go build -ldflags "-s -w -X main.version=$TAG" -o ace-${{ matrix.goos }}-${{ matrix.arch }} -v .
         env:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.arch }}
@@ -44,7 +55,7 @@ jobs:
             --output-certificate ace-${{ matrix.goos }}-${{ matrix.arch }}.pem
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: ace-${{ matrix.goos }}-${{ matrix.arch }}
           path: |
@@ -58,22 +69,33 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write # needed for creating the release
+    env:
+      TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           path: dist
           merge-multiple: true
 
+      # --target sets where the tag is created when it does not exist yet
+      # (workflow_dispatch); it is ignored when the tag already exists (tag
+      # push). Publishing with the workflow token does not trigger another
+      # run of this workflow.
       - name: Create Release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create "$GITHUB_REF_NAME" \
+          if [[ "$TAG" != v* ]]; then
+            echo "::error::tag must start with 'v', got '$TAG'"
+            exit 1
+          fi
+          gh release create "$TAG" \
             --repo "$GITHUB_REPOSITORY" \
             --draft \
             --generate-notes \
+            --target "$GITHUB_SHA" \
             dist/*
-          gh release edit "$GITHUB_REF_NAME" \
+          gh release edit "$TAG" \
             --repo "$GITHUB_REPOSITORY" \
             --draft=false

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,8 +9,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
       - run: go build -v -cover -ldflags '-s -w -X main.version=test' -o ace .
@@ -23,7 +23,7 @@ jobs:
   govulncheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: golang/govulncheck-action@v1
         with:
           go-version-file: go.mod


### PR DESCRIPTION
## What

### Release from the Actions tab
Adds a `workflow_dispatch` trigger to the release workflow with a `tag` input. Actions → Release → "Run workflow" → enter e.g. `v0.7.2`, and the workflow builds from the dispatched commit and passes the tag to `gh release create --target $GITHUB_SHA`, so the tag is created when the draft release is published. Two details worth noting:

- `--target` is ignored when the tag already exists, so the tag-push path (`git push origin v0.7.2`) keeps working unchanged — both entry points share the same jobs.
- The tag/release is created with the workflow's own `GITHUB_TOKEN`, which does not trigger new workflow runs, so a dispatch does not also start a duplicate tag-push run.

The tag input is validated to start with `v` before anything is created.

### Node 24 action bumps
The runners currently warn `Node.js 20 is deprecated. The following actions target Node.js 20...` on every job. Bumped the affected actions to their Node 24 majors in both workflows:

- `actions/checkout` v4 → v5
- `actions/setup-go` v5 → v6
- `actions/upload-artifact` v4 → v5
- `actions/download-artifact` v4 → v6

`sigstore/cosign-installer` and `golang/govulncheck-action` are untouched — the warning doesn't name them.

## Verification note

Workflow changes can't be fully exercised until merged; YAML is validated and the release flow logic (draft with assets → publish) is unchanged from the version that just shipped v0.7.1 successfully. The artifact-action bumps are the riskiest part — if the first dispatch run hiccups on them, it fails before creating anything, so nothing is left half-released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W6XiCMKgVz5khscQFxPFaC

---
_Generated by [Claude Code](https://claude.ai/code/session_01W6XiCMKgVz5khscQFxPFaC)_