### PR TITLE
set: validate variable names before writing

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -14,6 +14,7 @@ import (
 	"syscall"
 	"testing"
 	"time"
+	"unicode"
 
 	"github.com/middle-management/ace/internal/test"
 )
@@ -293,6 +294,28 @@ func TestAce(t *testing.T) {
 		}
 		if _, err := os.Stat("testdata/.env_invalid_pair.ace"); !errors.Is(err, fs.ErrNotExist) {
 			t.Fatal("expected no file to be written when a pair is invalid")
+		}
+	})
+
+	t.Run("set with invalid key writes nothing", func(t *testing.T) {
+		for name, pair := range map[string]string{
+			"newline":    "A\nB=1",
+			"space":      "A B=1",
+			"tab":        "A\tB=1",
+			"comment":    "#A=1",
+			"empty name": "=1",
+		} {
+			t.Run(name, func(t *testing.T) {
+				os.Remove("testdata/.env_invalid_key.ace")
+				cmd := &Set{EnvFile: "testdata/.env_invalid_key.ace", RecipientFiles: []string{"testdata/recipients1.txt"}, EnvPairs: []string{pair}}
+				err := cmd.Run()
+				if err == nil {
+					t.Fatalf("expected an error for key of %q, but none occurred", pair)
+				}
+				if _, err := os.Stat("testdata/.env_invalid_key.ace"); !errors.Is(err, fs.ErrNotExist) {
+					t.Fatal("expected no file to be written when a key is invalid")
+				}
+			})
 		}
 	})
 
@@ -640,6 +663,7 @@ func TestIntegration(t *testing.T) {
 		{1, []string{"ace", "set", "-e=testdata/.env.invalid.ace", "A=1", "B=2"}, nil},
 		{1, []string{"ace", "get", "-e=testdata/.env.invalid.ace", "-i=testdata/nonexistent_identity.txt"}, nil},
 		{1, []string{"ace", "set", "-e=testdata/.env1.ace", "-r=invalid"}, nil},
+		{1, []string{"ace", "set", "-e=testdata/.env1.ace", "-R=testdata/recipients1.txt", "BAD KEY=1"}, nil},
 		{0, []string{"ace", "env", "-e=testdata/.env.invalid.ace", "-i=testdata/identity1", "--on-missing=warn", "--", "sh", "-c", "echo $A"}, nil},
 		{0, []string{"ace", "env", "-e=testdata/.env.invalid.ace", "-i=testdata/identity1", "--on-missing=ignore", "--", "sh", "-c", "echo $A"}, nil},
 		{1, []string{"ace", "env", "-e=testdata/.env.invalid.ace", "--", "sh", "-c", "echo $A"}, nil},
@@ -804,6 +828,27 @@ func TestSignalForwarding(t *testing.T) {
 		cmd.Process.Kill()
 		t.Fatal("ace did not exit after SIGTERM, signal was not forwarded")
 	}
+}
+
+func FuzzUnescapeValue(f *testing.F) {
+	for _, seed := range []string{
+		"", "plain value", `"double quoted"`, `'single quoted'`,
+		`"escaped \" quote"`, "\"multi\nline\"", `'unclosed`, `"trailing \`,
+		`  "leading space"`, `mixed 'quotes' "here"`, `back\slash`,
+	} {
+		f.Add(seed)
+	}
+	f.Fuzz(func(t *testing.T, value string) {
+		unescaped, err := UnescapeValue(value)
+		if err != nil {
+			return
+		}
+		// values that don't start with a quote must pass through unchanged
+		trimmed := strings.TrimLeftFunc(value, unicode.IsSpace)
+		if len(trimmed) > 0 && trimmed[0] != '\'' && trimmed[0] != '"' && unescaped != value {
+			t.Fatalf("unquoted value %q was altered to %q", value, unescaped)
+		}
+	})
 }
 
 func sanitizeTestName(name string) string {

--- a/set.go
+++ b/set.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"crypto/rand"
 	"encoding/base32"
+	"fmt"
 	"io"
 	"os"
 	"strings"
+	"unicode"
 
 	"filippo.io/age"
 	"golang.org/x/crypto/chacha20poly1305"
@@ -17,6 +19,27 @@ type Set struct {
 	Recipients     []string `arg:"--recipient,-r,separate" help:"Encrypt to the specified RECIPIENT. Can be repeated."`
 	EnvFile        string   `arg:"--env-file,-e" default:"./.env.ace" help:"Append the encrypted variables to this file"`
 	EnvPairs       []string `arg:"positional" placeholder:"KEY=VALUE" help:"Variables to encrypt. When none are given they are read from stdin in .env format, which keeps values out of shell history"`
+}
+
+// validateKey rejects variable names that would corrupt the env file:
+// names are stored in plain text in a line-oriented format, so a newline
+// would split the entry (making the whole file undecryptable, since the
+// name is bound into the value's AEAD), other whitespace or control
+// characters produce entries the format cannot represent, and a leading
+// '#' would be skipped as a comment when reading
+func validateKey(key string) error {
+	if key == "" {
+		return fmt.Errorf("empty variable name")
+	}
+	if key[0] == '#' {
+		return fmt.Errorf("invalid variable name %q: must not start with '#'", key)
+	}
+	for _, r := range key {
+		if unicode.IsSpace(r) || unicode.IsControl(r) {
+			return fmt.Errorf("invalid variable name %q: must not contain whitespace or control characters", key)
+		}
+	}
+	return nil
 }
 
 func parseRecipients(recs []string, files []string) ([]age.Recipient, error) {
@@ -149,6 +172,9 @@ func (cmd *Set) Run() error {
 		pair := strings.SplitN(p, "=", 2)
 		if len(pair) != 2 {
 			continue
+		}
+		if err := validateKey(pair[0]); err != nil {
+			return err
 		}
 		if _, err := UnescapeValue(pair[1]); err != nil {
 			return err

--- a/testdata/TestIntegration/ace_set_-e=testdata_.env1.ace_-R=testdata_recipients1.txt_BAD_KEY=1
+++ b/testdata/TestIntegration/ace_set_-e=testdata_.env1.ace_-R=testdata_recipients1.txt_BAD_KEY=1
@@ -1,0 +1,1 @@
+ERROR: invalid variable name "BAD KEY": must not contain whitespace or control characters

--- a/testdata/TestIntegration/coverage
+++ b/testdata/TestIntegration/coverage
@@ -10,9 +10,10 @@ github.com/middle-management/ace/main.go:201:			readIdentities			66.7%
 github.com/middle-management/ace/main.go:261:			UnescapeValue			80.8%
 github.com/middle-management/ace/main.go:351:			main				100.0%
 github.com/middle-management/ace/rotate.go:22:			*Rotate.Run			70.0%
-github.com/middle-management/ace/set.go:22:			parseRecipients			100.0%
-github.com/middle-management/ace/set.go:54:			encryptBlock			78.6%
-github.com/middle-management/ace/set.go:103:			*Set.Run			80.0%
+github.com/middle-management/ace/set.go:30:			validateKey			75.0%
+github.com/middle-management/ace/set.go:45:			parseRecipients			100.0%
+github.com/middle-management/ace/set.go:77:			encryptBlock			78.6%
+github.com/middle-management/ace/set.go:126:			*Set.Run			80.8%
 github.com/middle-management/ace/version.go:14:			*Version.Run			60.0%
 github.com/middle-management/ace/version.go:23:			getVersion			0.0%
 github.com/middle-management/ace/internal/proc/proc.go:8:	SetupSysProcAttr		100.0%
@@ -21,4 +22,4 @@ github.com/middle-management/ace/internal/proc/proc.go:16:	ExitCode			100.0%
 github.com/middle-management/ace/internal/proc/proc_unix.go:14:	setupSysProcAttr		66.7%
 github.com/middle-management/ace/internal/proc/proc_unix.go:33:	forwardSignal			0.0%
 github.com/middle-management/ace/internal/proc/proc_unix.go:43:	exitCode			100.0%
-total								(statements)			75.8%
+total								(statements)			75.9%


### PR DESCRIPTION
## Problem

Variable names are stored in plain text in a line-oriented format, and `set` wrote them verbatim. A name containing a newline (e.g. `ace set $'FOO\nBAR=x'`) split its entry across two lines — and because since v2 the name is bound into the value's AEAD, the resulting line decrypts under the wrong name and **makes the whole file undecryptable for every reader** (readEnvFile aborts on the authentication failure). Other whitespace/control characters produce entries the format can't represent, and a name starting with `#` is silently skipped as a comment when reading.

## Fix

`set` now rejects empty names, names containing whitespace or control characters, and names starting with `#` — before anything is appended, so a bad pair never leaves a partial block (same guarantee the value validation already had).

Deliberately *not* enforced: a strict POSIX `[A-Za-z_][A-Za-z0-9_]*` pattern, to avoid breaking anyone using dots/dashes in names. Validation only covers what actually corrupts the file or silently disappears.

Also adds a fuzz target for `UnescapeValue`, which handles the value side of each pair.

## Tests

- Unit subtests for newline/space/tab/`#`-prefix/empty names, asserting no file is written.
- Integration row asserting `ace set "BAD KEY=1"` exits 1.

Note: `testdata/TestIntegration/` is regenerated by `make test`; the coverage snapshot may conflict trivially with sibling PRs — re-running `make test` resolves it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNWG5sA6riGB2qnEjMnbai

---
_Generated by [Claude Code](https://claude.ai/code/session_01NNWG5sA6riGB2qnEjMnbai)_