### PR TITLE
get: fail when a requested key has no readable value

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ ACE was meant for a workflow where a project can store all secrets in the git re
 
 - `ace set [KEY=VALUE...]`: Sets environment variables. Accepts multiple key-value pairs.
 - `ace set < .env`: Sets variables from a file formatted as KEY=VALUE per line.
-- `ace get [KEY...]`: Retrieves the values of specified environment variables.
+- `ace get [KEY...]`: Retrieves the values of specified environment variables. Exits non-zero when a requested variable has no value readable by the given identities.
 - `ace rotate`: Re-encrypts all variables into a single block for the given recipients, replacing the file.
 - `ace env -- COMMAND WITH ARGS...`: Executes a command with the environment variables loaded. Use `ace env` as a docker entrypoint to have it load secrets into environment of the command.
 

--- a/get.go
+++ b/get.go
@@ -26,16 +26,17 @@ func (cmd *Get) Run() error {
 
 	vars, _, err := readEnvFile(src, identities, true)
 	if err != nil {
-		return err
+		return fmt.Errorf("%s: %w", cmd.EnvFile, err)
 	}
 
+	found := make(map[string]bool, len(cmd.Keys))
 	for _, kv := range vars {
 		if len(cmd.Keys) > 0 {
 			var match bool
 			for _, k := range cmd.Keys {
 				if strings.HasPrefix(kv, k+"=") {
 					match = true
-					break
+					found[k] = true
 				}
 			}
 			if !match {
@@ -43,6 +44,19 @@ func (cmd *Get) Run() error {
 			}
 		}
 		fmt.Fprintln(output, kv)
+	}
+
+	// fail when a requested key has no readable value, so scripts can
+	// distinguish an unset variable from an empty one
+	var missing []string
+	for _, k := range cmd.Keys {
+		if !found[k] {
+			found[k] = true // dedupe repeated keys
+			missing = append(missing, k)
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("no readable value for: %s", strings.Join(missing, ", "))
 	}
 
 	return nil

--- a/main_test.go
+++ b/main_test.go
@@ -319,6 +319,34 @@ func TestAce(t *testing.T) {
 		}
 	})
 
+	t.Run("get missing key fails", func(t *testing.T) {
+		os.Remove("testdata/.env_missing_key.ace")
+		{
+			cmd := &Set{EnvFile: "testdata/.env_missing_key.ace", RecipientFiles: []string{"testdata/recipients1.txt"}, EnvPairs: []string{"A=1"}}
+			if err := cmd.Run(); err != nil {
+				t.Fatal(err)
+			}
+		}
+		{
+			buf := &bytes.Buffer{}
+			output = buf
+			cmd := &Get{EnvFile: "testdata/.env_missing_key.ace", Identities: []string{"testdata/identity1"}, Keys: []string{"A", "NOPE"}}
+			err := cmd.Run()
+			if err == nil || !strings.Contains(err.Error(), "NOPE") {
+				t.Fatalf("expected an error naming the missing key, got %v", err)
+			}
+			if got, want := buf.String(), "A=1\n"; got != want {
+				t.Fatalf("expected the readable keys to still be printed, got %q want %q", got, want)
+			}
+		}
+		{
+			cmd := &Get{EnvFile: "testdata/.env_missing_key.ace", Identities: []string{"testdata/identity1"}, Keys: []string{"A"}}
+			if err := cmd.Run(); err != nil {
+				t.Fatal(err)
+			}
+		}
+	})
+
 	t.Run("set with no pairs writes nothing", func(t *testing.T) {
 		os.Remove("testdata/.env_no_pairs.ace")
 		input = strings.NewReader("# only a comment\nno equals sign\n")
@@ -682,6 +710,7 @@ func TestIntegration(t *testing.T) {
 		{0, []string{"rm", "-f", "testdata/.envi3.ace"}, nil},
 		{0, []string{"ace", "set", "-e=testdata/.envi3.ace", "-R=testdata/recipients1.txt", "A=1", "B=2", "C=1 2 3 "}, nil},
 		{0, []string{"ace", "get", "-e=testdata/.envi3.ace", "-i=testdata/identity1", "A"}, nil},
+		{1, []string{"ace", "get", "-e=testdata/.envi3.ace", "-i=testdata/identity1", "A", "NOPE"}, nil},
 
 		{0, []string{"rm", "-f", "testdata/.envi4.ace"}, nil},
 		{0, []string{"ace", "set", "-e=testdata/.envi4.ace", "-R=testdata/recipients1.txt", "-R=testdata/recipients2.txt", "A=1", "B=2", "C=1 2 3 "}, nil},

--- a/testdata/TestIntegration/ace_get_-e=testdata_.envi3.ace_-i=testdata_identity1_A_NOPE
+++ b/testdata/TestIntegration/ace_get_-e=testdata_.envi3.ace_-i=testdata_identity1_A_NOPE
@@ -1,0 +1,2 @@
+A=1
+ERROR: no readable value for: NOPE

--- a/testdata/TestIntegration/coverage
+++ b/testdata/TestIntegration/coverage
@@ -2,7 +2,7 @@ github.com/middle-management/ace/env.go:22:			*Env.Run			83.3%
 github.com/middle-management/ace/env.go:105:			*childExitError.Error		100.0%
 github.com/middle-management/ace/env.go:106:			*childExitError.Unwrap		0.0%
 github.com/middle-management/ace/env.go:107:			*childExitError.ExitCode	100.0%
-github.com/middle-management/ace/get.go:15:			*Get.Run			90.5%
+github.com/middle-management/ace/get.go:15:			*Get.Run			93.1%
 github.com/middle-management/ace/main.go:31:			Main.Description		100.0%
 github.com/middle-management/ace/main.go:43:			Main.Epilogue			100.0%
 github.com/middle-management/ace/main.go:80:			readEnvFile			84.7%
@@ -22,4 +22,4 @@ github.com/middle-management/ace/internal/proc/proc.go:16:	ExitCode			100.0%
 github.com/middle-management/ace/internal/proc/proc_unix.go:14:	setupSysProcAttr		66.7%
 github.com/middle-management/ace/internal/proc/proc_unix.go:33:	forwardSignal			0.0%
 github.com/middle-management/ace/internal/proc/proc_unix.go:43:	exitCode			100.0%
-total								(statements)			75.9%
+total								(statements)			76.3%


### PR DESCRIPTION
## Problem

`ace get MISSING` exited 0 with no output, so scripts (CI guards especially) couldn't distinguish "variable not set / not readable by my identity" from "value is empty".

## Fix

When explicit keys are requested, any key with no value readable by the given identities now produces an error naming the missing keys and a non-zero exit. Readable keys are still printed first, so partial output remains usable. `ace get` with no arguments is unchanged. Read errors from the env file now also name the file.

Documented in the README's API reference.

## Tests

- Unit subtest: `get A NOPE` errors naming `NOPE` while still printing `A=1`; `get A` alone stays exit 0.
- Integration row asserting exit code 1.

Note: `testdata/TestIntegration/` is regenerated by `make test`; the coverage snapshot may conflict trivially with sibling PRs — re-running `make test` resolves it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNWG5sA6riGB2qnEjMnbai

---
_Generated by [Claude Code](https://claude.ai/code/session_01NNWG5sA6riGB2qnEjMnbai)_