### PR TITLE
rotate: preserve permissions, fsync, warn on self-lockout

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -514,6 +514,32 @@ func TestAce(t *testing.T) {
 		})
 	})
 
+	t.Run("rotate preserves file permissions", func(t *testing.T) {
+		os.Remove("testdata/.env_rotate_mode.ace")
+		{
+			cmd := &Set{EnvFile: "testdata/.env_rotate_mode.ace", RecipientFiles: []string{"testdata/recipients1.txt"}, EnvPairs: []string{"A=1"}}
+			if err := cmd.Run(); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if err := os.Chmod("testdata/.env_rotate_mode.ace", 0600); err != nil {
+			t.Fatal(err)
+		}
+		{
+			cmd := &Rotate{EnvFile: "testdata/.env_rotate_mode.ace", RecipientFiles: []string{"testdata/recipients1.txt"}, Identities: []string{"testdata/identity1"}}
+			if err := cmd.Run(); err != nil {
+				t.Fatal(err)
+			}
+		}
+		fi, err := os.Stat("testdata/.env_rotate_mode.ace")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got, want := fi.Mode().Perm(), os.FileMode(0600); got != want {
+			t.Fatalf("expected rotate to preserve mode %v, got %v", want, got)
+		}
+	})
+
 	t.Run("rotate refuses when a block cannot be decrypted", func(t *testing.T) {
 		os.Remove("testdata/.env_rotate_refuse.ace")
 		{

--- a/rotate.go
+++ b/rotate.go
@@ -3,15 +3,18 @@ package main
 import (
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"filippo.io/age"
 )
 
 type Rotate struct {
 	RecipientFiles []string `arg:"--recipient-file,-R,separate" help:"Encrypt to recipients listed at RECIPIENT-FILE. Can be repeated. Defaults to ./recipients.txt"`
 	Recipients     []string `arg:"--recipient,-r,separate" help:"Encrypt to the specified RECIPIENT. Can be repeated."`
-	EnvFile        string   `arg:"--env-file,-e" default:"./.env.ace"`
+	EnvFile        string   `arg:"--env-file,-e" default:"./.env.ace" help:"Rewrite this file with the re-encrypted variables"`
 	Identities     []string `arg:"--identity,-i,separate" help:"Decrypt using the specified IDENTITY. Can be repeated. Defaults to $XDG_CONFIG_HOME/ace/identity"`
 }
 
@@ -36,7 +39,11 @@ func (cmd *Rotate) Run() error {
 			return nil, envFileStats{}, err
 		}
 		defer src.Close()
-		return readEnvFile(src, identities, true)
+		vars, stats, err := readEnvFile(src, identities, true)
+		if err != nil {
+			err = fmt.Errorf("%s: %w", cmd.EnvFile, err)
+		}
+		return vars, stats, err
 	}()
 	if err != nil {
 		return err
@@ -44,6 +51,8 @@ func (cmd *Rotate) Run() error {
 	if stats.matched < stats.blocks {
 		return fmt.Errorf("refusing to rotate: %d of %d blocks could not be decrypted with the available identities, their vars would be lost", stats.blocks-stats.matched, stats.blocks)
 	}
+
+	warnOnSelfLockout(identities, recipients)
 
 	var kvs [][2]string
 	for _, kv := range vars {
@@ -62,6 +71,12 @@ func (cmd *Rotate) Run() error {
 		}
 	}
 
+	// keep the permissions of the file being replaced
+	mode := os.FileMode(0644)
+	if fi, err := os.Stat(cmd.EnvFile); err == nil {
+		mode = fi.Mode().Perm()
+	}
+
 	// write to a temp file in the same directory and rename it over the
 	// original, so a failed rotation never leaves a truncated env file
 	tmp, err := os.CreateTemp(filepath.Dir(cmd.EnvFile), filepath.Base(cmd.EnvFile)+".rotate*")
@@ -74,7 +89,11 @@ func (cmd *Rotate) Run() error {
 		tmp.Close()
 		return err
 	}
-	if err := tmp.Chmod(0644); err != nil {
+	if err := tmp.Chmod(mode); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
 		tmp.Close()
 		return err
 	}
@@ -83,4 +102,25 @@ func (cmd *Rotate) Run() error {
 	}
 
 	return os.Rename(tmp.Name(), cmd.EnvFile)
+}
+
+// warnOnSelfLockout warns when none of the identities that just decrypted
+// the file are among the new recipients, since the rotated file would be
+// unreadable to the caller. Only X25519 keys can be compared, so the check
+// is skipped when any other recipient type is present.
+func warnOnSelfLockout(identities []age.Identity, recipients []age.Recipient) {
+	recSet := map[string]bool{}
+	for _, r := range recipients {
+		x, ok := r.(*age.X25519Recipient)
+		if !ok {
+			return
+		}
+		recSet[x.String()] = true
+	}
+	for _, id := range identities {
+		if x, ok := id.(*age.X25519Identity); ok && recSet[x.Recipient().String()] {
+			return
+		}
+	}
+	slog.Warn("none of the identities are among the new recipients, the rotated file will not be readable with them")
 }

--- a/testdata/TestIntegration/coverage
+++ b/testdata/TestIntegration/coverage
@@ -9,7 +9,8 @@ github.com/middle-management/ace/main.go:80:			readEnvFile			84.7%
 github.com/middle-management/ace/main.go:201:			readIdentities			66.7%
 github.com/middle-management/ace/main.go:261:			UnescapeValue			80.8%
 github.com/middle-management/ace/main.go:351:			main				100.0%
-github.com/middle-management/ace/rotate.go:22:			*Rotate.Run			70.0%
+github.com/middle-management/ace/rotate.go:25:			*Rotate.Run			70.0%
+github.com/middle-management/ace/rotate.go:111:			warnOnSelfLockout		80.0%
 github.com/middle-management/ace/set.go:30:			validateKey			75.0%
 github.com/middle-management/ace/set.go:45:			parseRecipients			100.0%
 github.com/middle-management/ace/set.go:77:			encryptBlock			78.6%


### PR DESCRIPTION
Three hardening fixes for `rotate`, which rewrites the whole env file:

- **Preserve file permissions.** The temp file was always chmod'd 0644, silently resetting whatever mode the original file had (e.g. 0600). It now keeps the mode of the file being replaced.
- **fsync before rename.** The atomic temp-file+rename dance could still leave an empty file after a crash, since the data was never flushed before the rename. The temp file is now synced before closing.
- **Warn on self-lockout.** Rotating to a recipient set that includes none of the identities that just decrypted the file usually means the caller is locking themselves out of the result. A warning is logged before writing (skipped when non-X25519 recipients are present, since those can't be compared against identities — no false positives). Intentional handoffs still work; it's a warning, not an error.

Also names the env file in read errors and adds the missing `--env-file` help text.

## Tests

Unit subtest asserting a 0600 file is still 0600 after rotate.

Note: `testdata/TestIntegration/` is regenerated by `make test`; the coverage snapshot may conflict trivially with sibling PRs — re-running `make test` resolves it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNWG5sA6riGB2qnEjMnbai

---
_Generated by [Claude Code](https://claude.ai/code/session_01NNWG5sA6riGB2qnEjMnbai)_