### PR TITLE
readEnvFile: name the line and variable in errors

### DIFF
--- a/env.go
+++ b/env.go
@@ -60,7 +60,7 @@ func (cmd *Env) Run() error {
 		} else {
 			vars, _, err = readEnvFile(src, identities, false)
 			if err != nil {
-				return err
+				return fmt.Errorf("%s: %w", cmd.EnvFile, err)
 			}
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -87,7 +87,9 @@ func readEnvFile(src io.Reader, identities []age.Identity, keepQuotes bool) ([]s
 	s.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
 	var aead cipher.AEAD
 	var bindKey bool
+	var lineNo int
 	for s.Scan() {
+		lineNo++
 		line := strings.TrimSpace(s.Text())
 
 		// split on block prefix
@@ -101,14 +103,14 @@ func readEnvFile(src io.Reader, identities []age.Identity, keepQuotes bool) ([]s
 				prefix = ACE_PREFIX_V2
 				bindKey = true
 			default:
-				return nil, stats, fmt.Errorf("unsupported block version %q, upgrade ace to read this file", strings.SplitN(line, ":", 2)[0])
+				return nil, stats, fmt.Errorf("line %d: unsupported block version %q, upgrade ace to read this file", lineNo, strings.SplitN(line, ":", 2)[0])
 			}
 			stats.blocks++
 
 			// base32decode and armor decode age header
 			header, err := base32.StdEncoding.DecodeString(strings.TrimPrefix(line, prefix))
 			if err != nil {
-				return nil, stats, err
+				return nil, stats, fmt.Errorf("line %d: block header: %w", lineNo, err)
 			}
 
 			var r io.Reader
@@ -122,15 +124,15 @@ func readEnvFile(src io.Reader, identities []age.Identity, keepQuotes bool) ([]s
 				aead = nil
 				continue
 			} else if err != nil {
-				return nil, stats, err
+				return nil, stats, fmt.Errorf("line %d: block header: %w", lineNo, err)
 			}
 			blockKey, err := io.ReadAll(r)
 			if err != nil {
-				return nil, stats, err
+				return nil, stats, fmt.Errorf("line %d: block header: %w", lineNo, err)
 			}
 			aead, err = chacha20poly1305.NewX(blockKey)
 			if err != nil {
-				return nil, stats, err
+				return nil, stats, fmt.Errorf("line %d: block header: %w", lineNo, err)
 			}
 			stats.matched++
 		}
@@ -151,11 +153,11 @@ func readEnvFile(src io.Reader, identities []age.Identity, keepQuotes bool) ([]s
 
 		secret, err := base32.StdEncoding.DecodeString(pair[1])
 		if err != nil {
-			return nil, stats, err
+			return nil, stats, fmt.Errorf("line %d: %s: %w", lineNo, pair[0], err)
 		}
 
 		if len(secret) < aead.NonceSize() {
-			return nil, stats, fmt.Errorf("ciphertext too short")
+			return nil, stats, fmt.Errorf("line %d: %s: ciphertext too short", lineNo, pair[0])
 		}
 		nonce, ciphertext := secret[:aead.NonceSize()], secret[aead.NonceSize():]
 
@@ -167,7 +169,7 @@ func readEnvFile(src io.Reader, identities []age.Identity, keepQuotes bool) ([]s
 		// Decrypt the message and check it wasn't tampered with.
 		plaintext, err := aead.Open(nil, nonce, ciphertext, aad)
 		if err != nil {
-			return nil, stats, err
+			return nil, stats, fmt.Errorf("line %d: %s: %w", lineNo, pair[0], err)
 		}
 
 		if _, exists := vals[pair[0]]; !exists {

--- a/main_test.go
+++ b/main_test.go
@@ -583,8 +583,8 @@ func TestAce(t *testing.T) {
 		}
 		cmd := &Get{EnvFile: "testdata/.env_future.ace", Identities: []string{"testdata/identity1"}}
 		err := cmd.Run()
-		if err == nil || !strings.Contains(err.Error(), "unsupported block version") {
-			t.Fatalf("expected unsupported block version error, got %v", err)
+		if err == nil || !strings.Contains(err.Error(), "line 1: unsupported block version") {
+			t.Fatalf("expected unsupported block version error with line context, got %v", err)
 		}
 	})
 

--- a/testdata/TestIntegration/coverage
+++ b/testdata/TestIntegration/coverage
@@ -5,10 +5,10 @@ github.com/middle-management/ace/env.go:107:			*childExitError.ExitCode	100.0%
 github.com/middle-management/ace/get.go:15:			*Get.Run			93.1%
 github.com/middle-management/ace/main.go:31:			Main.Description		100.0%
 github.com/middle-management/ace/main.go:43:			Main.Epilogue			100.0%
-github.com/middle-management/ace/main.go:80:			readEnvFile			84.7%
-github.com/middle-management/ace/main.go:201:			readIdentities			66.7%
-github.com/middle-management/ace/main.go:261:			UnescapeValue			80.8%
-github.com/middle-management/ace/main.go:351:			main				100.0%
+github.com/middle-management/ace/main.go:80:			readEnvFile			85.1%
+github.com/middle-management/ace/main.go:203:			readIdentities			66.7%
+github.com/middle-management/ace/main.go:263:			UnescapeValue			80.8%
+github.com/middle-management/ace/main.go:353:			main				100.0%
 github.com/middle-management/ace/rotate.go:25:			*Rotate.Run			70.0%
 github.com/middle-management/ace/rotate.go:111:			warnOnSelfLockout		80.0%
 github.com/middle-management/ace/set.go:30:			validateKey			75.0%
@@ -23,4 +23,4 @@ github.com/middle-management/ace/internal/proc/proc.go:16:	ExitCode			100.0%
 github.com/middle-management/ace/internal/proc/proc_unix.go:14:	setupSysProcAttr		66.7%
 github.com/middle-management/ace/internal/proc/proc_unix.go:33:	forwardSignal			0.0%
 github.com/middle-management/ace/internal/proc/proc_unix.go:43:	exitCode			100.0%
-total								(statements)			76.3%
+total								(statements)			76.4%


### PR DESCRIPTION
A decode or decryption failure used to surface as a bare message like `ciphertext too short` or `message authentication failed`, with no way to tell which of the file's lines was at fault — painful in an append-only file that many people and machines write to.

Errors from `readEnvFile` now carry the line number, and value errors also name the variable, e.g.:

```
ERROR: ./.env.ace: line 7: API_KEY: chacha20poly1305: message authentication failed
```

`env` additionally prefixes the error with the file name (`get` and `rotate` gain the same prefix in their respective PRs, folded there to avoid overlapping diffs).

The existing unsupported-block-version test is tightened to assert the line context.

Note: `testdata/TestIntegration/` is regenerated by `make test`; the coverage snapshot may conflict trivially with sibling PRs — re-running `make test` resolves it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNWG5sA6riGB2qnEjMnbai

---
_Generated by [Claude Code](https://claude.ai/code/session_01NNWG5sA6riGB2qnEjMnbai)_