### PR TITLE
Add --version flag, document plaintext metadata caveat

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,3 +134,5 @@ ace versions that only know v1 cannot read v2 blocks.
 
 ACE leans on the simple and reliable age-encryption.org. The security of this implementation has not been vetted by security professionals, and keeping keys secure is outside of the scope of this tool.
 
+Note that only values are encrypted: variable names (and the number and size of values) are visible in plain text to anyone who can read the file. Do not put sensitive information in variable names.
+

--- a/main.go
+++ b/main.go
@@ -21,11 +21,11 @@ import (
 )
 
 type Main struct {
-	Env     *Env     `arg:"subcommand:env" help:"Run a command with the decrypted env vars added to its environment"`
-	Get     *Get     `arg:"subcommand:get" help:"Decrypt and print env vars"`
-	Set     *Set     `arg:"subcommand:set" help:"Encrypt env vars and append them to the env file"`
-	Rotate  *Rotate  `arg:"subcommand:rotate" help:"Re-encrypt all env vars into a single block for the given recipients, replacing the env file"`
-	Version *Version `arg:"subcommand:version" help:"Print version"`
+	Env    *Env     `arg:"subcommand:env" help:"Run a command with the decrypted env vars added to its environment"`
+	Get    *Get     `arg:"subcommand:get" help:"Decrypt and print env vars"`
+	Set    *Set     `arg:"subcommand:set" help:"Encrypt env vars and append them to the env file"`
+	Rotate *Rotate  `arg:"subcommand:rotate" help:"Re-encrypt all env vars into a single block for the given recipients, replacing the env file"`
+	Ver    *Version `arg:"subcommand:version" help:"Print version"`
 }
 
 func (Main) Description() string {
@@ -38,6 +38,14 @@ recipients can append new values, but only holders of a matching identity
 (private key) can decrypt them. Values are never modified in place: setting
 an existing key appends a new value, and the latest value wins when reading.
 `
+}
+
+// Version makes go-arg support --version in addition to the subcommand
+func (Main) Version() string {
+	if version == "" {
+		return "ace " + getVersion()
+	}
+	return "ace " + version
 }
 
 func (Main) Epilogue() string {
@@ -373,9 +381,9 @@ func main() {
 			return args.Set.Run()
 		case args.Rotate != nil:
 			return args.Rotate.Run()
-		case args.Version != nil:
-			args.Version.version = version
-			return args.Version.Run()
+		case args.Ver != nil:
+			args.Ver.version = version
+			return args.Ver.Run()
 		default:
 			p.WriteHelp(os.Stderr)
 			return nil

--- a/main_test.go
+++ b/main_test.go
@@ -714,6 +714,7 @@ func TestIntegration(t *testing.T) {
 	}{
 		{0, []string{"ace"}, nil},
 		{0, []string{"ace", "version"}, nil},
+		{0, []string{"ace", "--version"}, nil},
 		{1, []string{"ace", "set", "-e=testdata/.env.invalid.ace", "A=1", "B=2"}, nil},
 		{1, []string{"ace", "get", "-e=testdata/.env.invalid.ace", "-i=testdata/nonexistent_identity.txt"}, nil},
 		{1, []string{"ace", "set", "-e=testdata/.env1.ace", "-r=invalid"}, nil},

--- a/testdata/TestIntegration/ace
+++ b/testdata/TestIntegration/ace
@@ -7,10 +7,12 @@ recipients can append new values, but only holders of a matching identity
 (private key) can decrypt them. Values are never modified in place: setting
 an existing key appends a new value, and the latest value wins when reading.
 
+ace test
 Usage: ace <command> [<args>]
 
 Options:
   --help, -h             display this help and exit
+  --version              display version and exit
 
 Commands:
   env                    Run a command with the decrypted env vars added to its environment

--- a/testdata/TestIntegration/ace_--version
+++ b/testdata/TestIntegration/ace_--version
@@ -1,0 +1,1 @@
+ace test

--- a/testdata/TestIntegration/coverage
+++ b/testdata/TestIntegration/coverage
@@ -4,11 +4,12 @@ github.com/middle-management/ace/env.go:106:			*childExitError.Unwrap		0.0%
 github.com/middle-management/ace/env.go:107:			*childExitError.ExitCode	100.0%
 github.com/middle-management/ace/get.go:15:			*Get.Run			93.1%
 github.com/middle-management/ace/main.go:31:			Main.Description		100.0%
-github.com/middle-management/ace/main.go:43:			Main.Epilogue			100.0%
-github.com/middle-management/ace/main.go:80:			readEnvFile			85.1%
-github.com/middle-management/ace/main.go:203:			readIdentities			66.7%
-github.com/middle-management/ace/main.go:263:			UnescapeValue			80.8%
-github.com/middle-management/ace/main.go:353:			main				100.0%
+github.com/middle-management/ace/main.go:44:			Main.Version			66.7%
+github.com/middle-management/ace/main.go:51:			Main.Epilogue			100.0%
+github.com/middle-management/ace/main.go:88:			readEnvFile			85.1%
+github.com/middle-management/ace/main.go:211:			readIdentities			66.7%
+github.com/middle-management/ace/main.go:271:			UnescapeValue			80.8%
+github.com/middle-management/ace/main.go:361:			main				100.0%
 github.com/middle-management/ace/rotate.go:25:			*Rotate.Run			70.0%
 github.com/middle-management/ace/rotate.go:111:			warnOnSelfLockout		80.0%
 github.com/middle-management/ace/set.go:30:			validateKey			75.0%
@@ -23,4 +24,4 @@ github.com/middle-management/ace/internal/proc/proc.go:16:	ExitCode			100.0%
 github.com/middle-management/ace/internal/proc/proc_unix.go:14:	setupSysProcAttr		66.7%
 github.com/middle-management/ace/internal/proc/proc_unix.go:33:	forwardSignal			0.0%
 github.com/middle-management/ace/internal/proc/proc_unix.go:43:	exitCode			100.0%
-total								(statements)			76.4%
+total								(statements)			76.3%


### PR DESCRIPTION
Two small UX/docs items:

- **`--version` flag** via go-arg's `Version` interface, alongside the existing `version` subcommand. The `Main.Version` subcommand field is renamed to `Ver` to avoid colliding with the interface method — the CLI itself is unchanged (`ace version` still works, tag decides the name). The help output now shows the version line and `--version` option, so the help snapshot is updated.
- **README security note**: only values are encrypted — variable names (and the number/size of values) are plain text to anyone who can read the file, so names must not carry sensitive information. This was implicit in the file-format section; now it's stated where people look for security caveats.

## Tests

Integration row for `ace --version`.

Note: `testdata/TestIntegration/` is regenerated by `make test`; the coverage snapshot may conflict trivially with sibling PRs — re-running `make test` resolves it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNWG5sA6riGB2qnEjMnbai

---
_Generated by [Claude Code](https://claude.ai/code/session_01NNWG5sA6riGB2qnEjMnbai)_